### PR TITLE
fix: bump mcp to >=1.28.1 (3 CVEs)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.14.1",
     "async-lru>=2.0.5",
-    "mcp[cli]>=1.9.1",
+    "mcp[cli]>=1.28.1",
     "rapidfuzz>=3.14.3",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.14.1",
     "async-lru>=2.0.5",
-    "mcp[cli]>=1.28.1",
+    "mcp[cli]>=1.28.1,<2",
     "rapidfuzz>=3.14.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -382,7 +382,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "async-lru", specifier = ">=2.0.5" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1,<2" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,12 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -376,7 +382,7 @@ dev = [
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "async-lru", specifier = ">=2.0.5" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.9.1" },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28.1" },
     { name = "rapidfuzz", specifier = ">=3.14.3" },
 ]
 
@@ -611,7 +617,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi-proxy.cloud.databricks.com/simple/" }
 dependencies = [
     { name = "anyio" },
@@ -629,9 +635,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://pypi-proxy.cloud.databricks.com/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://pypi-proxy.cloud.databricks.com/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://pypi-proxy.cloud.databricks.com/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://pypi-proxy.cloud.databricks.com/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
- Bump `mcp[cli]` from ">=1.9.1" to ">=1.28.1,<2"
- Fixes CVE-2026-59950, CVE-2026-52870, CVE-2026-52869

## Test plan
- [ ] Verify `uv lock` resolves without conflicts
- [ ] Run existing tests to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)